### PR TITLE
Hotfix before create ausente no model task

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -4,6 +4,8 @@
 class Task < ApplicationRecord
   belongs_to :step
 
+  before_create :set_initial_task_position
+
   validates :content, presence: true
   validates :step, presence: true
 


### PR DESCRIPTION
Model task não estava chamando a função de inicializar posição antes da criação;